### PR TITLE
Change API to use body for parameters/Added mongoDB atlas support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,4 +16,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'com.google.zxing:core:3.4.1'
     implementation 'com.google.zxing:javase:3.4.1'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
+    implementation 'jakarta.servlet:jakarta.servlet-api:5.0.0'
+    implementation 'org.mongodb:mongodb-driver-sync:5.1.2'
 }

--- a/src/main/java/com/example/demo/config/MongoConfig.java
+++ b/src/main/java/com/example/demo/config/MongoConfig.java
@@ -1,0 +1,22 @@
+package com.example.demo.config;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MongoConfig {
+
+    @Bean
+    public MongoClient mongoClient() {
+        String uri = "mongodb+srv://insiderdavidlai:1999@urlbase.wq3pm.mongodb.net/?retryWrites=true&w=majority&appName=URLBase";
+        return MongoClients.create(uri);
+    }
+
+    @Bean
+    public MongoDatabase mongoDatabase(MongoClient mongoClient) {
+        return mongoClient.getDatabase("URLData");
+    }
+}

--- a/src/main/java/com/example/demo/controller/URLRedirectController.java
+++ b/src/main/java/com/example/demo/controller/URLRedirectController.java
@@ -1,0 +1,31 @@
+package com.example.demo.controller;
+
+import com.example.demo.service.URLService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Controller
+public class URLRedirectController {
+
+    private final URLService urlService;
+
+    @Autowired
+    public URLRedirectController(URLService urlService) {
+        this.urlService = urlService;
+    }
+
+    @GetMapping("/http://tiny.url/{shortURL}")
+    public void redirect(@PathVariable String shortURL, HttpServletResponse response) throws IOException {
+        String longURL = urlService.getLongURL(shortURL);
+        if (longURL != null) {
+            response.sendRedirect(longURL);
+        } else {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/controller/URLRedirectController.java
+++ b/src/main/java/com/example/demo/controller/URLRedirectController.java
@@ -18,10 +18,11 @@ public class URLRedirectController {
     public URLRedirectController(URLService urlService) {
         this.urlService = urlService;
     }
-
-    @GetMapping("/http://tiny.url/{shortURL}")
+    //Next step to delete tiny url from parameter
+    //Next step to consider how to handle if one link are shortened by two different methods and how to store it in db
+    @GetMapping("/r/{shortURL}")
     public void redirect(@PathVariable String shortURL, HttpServletResponse response) throws IOException {
-        String longURL = urlService.getLongURL(shortURL);
+        String longURL = urlService.getLongURL("http://tiny.url/" + shortURL);
         if (longURL != null) {
             response.sendRedirect(longURL);
         } else {

--- a/src/main/java/com/example/demo/dto/QRCodeRequest.java
+++ b/src/main/java/com/example/demo/dto/QRCodeRequest.java
@@ -1,0 +1,14 @@
+package com.example.demo.dto;
+
+public class QRCodeRequest {
+    private String url;
+
+    // Getters and Setters
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/src/main/java/com/example/demo/dto/RetrieveRequest.java
+++ b/src/main/java/com/example/demo/dto/RetrieveRequest.java
@@ -1,0 +1,24 @@
+package com.example.demo.dto;
+
+public class RetrieveRequest {
+    private String shortURL;
+    private String type;
+
+    // Getters and Setters
+    public String getShortURL() {
+        return shortURL;
+    }
+
+    public void setShortURL(String shortURL) {
+        this.shortURL = shortURL;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}
+

--- a/src/main/java/com/example/demo/dto/ShortenRequest.java
+++ b/src/main/java/com/example/demo/dto/ShortenRequest.java
@@ -1,0 +1,24 @@
+package com.example.demo.dto;
+
+public class ShortenRequest {
+    private String longURL;
+    private String type;
+
+    // Getters and Setters
+    public String getLongURL() {
+        return longURL;
+    }
+
+    public void setLongURL(String longURL) {
+        this.longURL = longURL;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}
+

--- a/src/main/java/com/example/demo/entity/URLMapping.java
+++ b/src/main/java/com/example/demo/entity/URLMapping.java
@@ -1,0 +1,48 @@
+package com.example.demo.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "URLMapping")
+public class URLMapping {
+
+    @Id
+    private String id;
+    private String shortURL;
+    private String longURL;
+    private String type;
+
+    // Getters and Setters
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getShortURL() {
+        return shortURL;
+    }
+
+    public void setShortURL(String shortURL) {
+        this.shortURL = shortURL;
+    }
+
+    public String getLongURL() {
+        return longURL;
+    }
+
+    public void setLongURL(String longURL) {
+        this.longURL = longURL;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,6 @@
 
 # Reduce logging level. Set logging level to warn
 logging.level.root=warn
+spring.data.mongodb.uri=mongodb+srv://insiderdavidlai:1999@urlbase.wq3pm.mongodb.net/?retryWrites=true&w=majority&appName=URLBase
+spring.data.mongodb.database=URLData
+logging.level.org.springframework=DEBUG


### PR DESCRIPTION
Embedded API parameters into one API body when using shorten, retrieve and QRCode APIs using DTO

Configure an atlas MongoDB and connected from SpringBoot 
Created entity of URLMapping to represent the MongoDB object including id, shortURL, longURL(original URL), type(Shorten method)
<img width="1676" alt="Screenshot 2024-09-03 at 22 39 04" src="https://github.com/user-attachments/assets/0dd8390f-da0b-46bb-a040-bea3ccd56987">
<img width="1676" alt="Screenshot 2024-09-03 at 22 39 59" src="https://github.com/user-attachments/assets/ed04c2f1-be0b-4f39-a8c0-f2ffac556c02">
